### PR TITLE
Reset the position of total_rewards and total_steps

### DIFF
--- a/ptan/experience.py
+++ b/ptan/experience.py
@@ -107,17 +107,18 @@ class ExperienceSource:
                         yield tuple(history)
                     states[idx] = next_state
                     if is_done:
-                        # in case of very short episode (shorter than our steps count), send gathered history
-                        if 0 < len(history) < self.steps_count:
-                            yield tuple(history)
                         # generate tail of history
-                        while len(history) > 1:
-                            history.popleft()
-                            yield tuple(history)
-                        self.total_rewards.append(cur_rewards[idx])
-                        self.total_steps.append(cur_steps[idx])
-                        cur_rewards[idx] = 0.0
-                        cur_steps[idx] = 0
+                        while 1<=len(history)<= self.steps_count:
+                            if len(history)==1:
+                                self.total_rewards.append(cur_rewards[idx])
+                                self.total_steps.append(cur_steps[idx])
+                                cur_rewards[idx] = 0.0
+                                cur_steps[idx] = 0
+                                yield tuple(history)
+                                break
+                            else:
+                                yield tuple(history)
+                                history.popleft()
                         # vectorized envs are reset automatically
                         states[idx] = env.reset() if not self.vectorized else None
                         agent_states[idx] = self.agent.initial_state()


### PR DESCRIPTION
because of the use of yield,when we get the last state from history,we can not get the total_rewards and total_steps in previous code. We can get them together with reset the state,but it is the next episode. 

So i 
1、modify the code behind "if is_done: ..."
2、Considering that could have many simple in "history"

do this modify,please approve，thanks.